### PR TITLE
No ABI Build Folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,7 @@ run_ganache:
 
 # 3) deploy xbr smart contract to blockchain
 deploy_ganache:
-	python ./check-abi-files.py
+	# python ./check-abi-files.py
 	$(TRUFFLE) migrate --reset --network ganache
 
 # 4) initialize blockchain data
@@ -234,6 +234,9 @@ run_ganache_docker:
 check_ganache:
 	python docker/init-blockchain.py --showonly --gateway http://localhost:1545
 
+# check ABI Files
+check_abi_files:
+	python ./check-abi-files.py
 
 #
 # build optimized SVG files from source SVGs


### PR DESCRIPTION
Moving check-abi-files.py to seperate make command, because it fails if there is no build/contracts folder.
truffle migrate has to be called to create ABI files in build/contracts.
```

albertk@os:~/proj/xbr_2020/xbr-protocol$ make deploy_ganache 
python ./check-abi-files.py
Traceback (most recent call last):
  File "./check-abi-files.py", line 9, in <module>
    for fn in os.listdir('build/contracts'):
OSError: [Errno 2] No such file or directory: 'build/contracts'
Makefile:205: recipe for target 'deploy_ganache' failed
make: *** [deploy_ganache] Error 1

```